### PR TITLE
rockchip: Enable QEMU package support in .config for Rockchip devices images

### DIFF
--- a/utils/qemu/Makefile
+++ b/utils/qemu/Makefile
@@ -31,7 +31,7 @@ include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-host.mk
 
 QEMU_DEPS_IN_GUEST := @(TARGET_x86||TARGET_x86_64||TARGET_armsr||TARGET_malta)
-QEMU_DEPS_IN_HOST := @(TARGET_x86_64||TARGET_armsr_armv8||TARGET_sunxi)
+QEMU_DEPS_IN_HOST := @(TARGET_x86_64||TARGET_armsr_armv8||TARGET_sunxi||TARGET_rockchip)
 QEMU_DEPS_IN_HOST += +libstdcpp
 QEMU_DEPS_IN_HOST += $(ICONV_DEPENDS)
 


### PR DESCRIPTION
OpenWRT's .config now support declaring qemu-* packages as part of the Rockchip devices OpenWRT images.

Maintainer: @yousong

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWRT snapshot
- **OpenWrt Target/Subtarget:** Rochchip / armv8
- **OpenWrt Device:** NanoPi R4S

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

